### PR TITLE
[PW-7153] Add hard wait before proceeding to payment methods page

### DIFF
--- a/projects/magento/pageObjects/checkout/ShippingDetails.page.js
+++ b/projects/magento/pageObjects/checkout/ShippingDetails.page.js
@@ -64,6 +64,10 @@ export class ShippingDetails {
     await this.fillShippingDetails(user);
     await this.page.waitForLoadState("domcontentloaded", { timeout: 10000 });
     await this.page.waitForLoadState("networkidle", { timeout: 10000 });
+
+    // Unavoidable hard wait until the payment method render issue is resolved
+    await new Promise(r => setTimeout(r, 500));
+
     await this.clickNextButton();
     await new AnimationHelper(this.page).waitForAnimation();
   }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Add hard wait of 500ms to avoid payment method render problem

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
PW-7153
