### PR TITLE
Change the way of checking assertions

### DIFF
--- a/projects/magento/helpers/ScenarioHelper.js
+++ b/projects/magento/helpers/ScenarioHelper.js
@@ -53,7 +53,7 @@ export async function verifySuccessfulPayment(page, redirect = true) {
   if (redirect != false) {
     await successfulCheckoutPage.waitForRedirection();
   }
-  await expect(await successfulCheckoutPage.pageTitle.innerText()).toEqual(
+  await expect(await successfulCheckoutPage.pageTitle.innerText()).toContain(
     "Thank you for your purchase!"
   );
 }
@@ -67,7 +67,7 @@ export async function verifyFailedPayment(page) {
   const errorMessage = await new ShoppingCartPage(
     page
   ).errorMessage.innerText();
-  await expect(errorMessage).toEqual(
+  await expect(errorMessage).toContain(
     "Your payment failed, Please try again later"
   );
 }

--- a/projects/magento/pageObjects/checkout/BancontactCardComponents.js
+++ b/projects/magento/pageObjects/checkout/BancontactCardComponents.js
@@ -55,7 +55,7 @@ export class BancontactCardComponents {
   }
 
   async verifyPaymentRefusal() {
-    await expect(await this.errorMessage.innerText()).toEqual(
+    await expect(await this.errorMessage.innerText()).toContain(
       "The payment is REFUSED."
     );
   }

--- a/projects/magento/pageObjects/checkout/CreditCardComponents.js
+++ b/projects/magento/pageObjects/checkout/CreditCardComponents.js
@@ -81,13 +81,13 @@ export class CreditCardComponents {
   }
 
   async verifyPaymentRefusal() {
-    await expect(await this.errorMessage.innerText()).toEqual(
+    await expect(await this.errorMessage.innerText()).toContain(
       "The payment is REFUSED."
     );
   }
 
   async verifyPaymentCancellation() {
-    await expect(await this.errorMessage.innerText()).toEqual(
+    await expect(await this.errorMessage.innerText()).toContain(
       "Payment has been cancelled"
     );
   }

--- a/projects/magento/pageObjects/plugin/ShoppingCart.page.js
+++ b/projects/magento/pageObjects/plugin/ShoppingCart.page.js
@@ -19,7 +19,7 @@ export class ShoppingCartPage extends BasePage {
       url: /.*checkout\/cart/,
       timeout: 10000,
     });
-    await expect(await this.errorMessage.innerText()).toEqual(
+    await expect(await this.errorMessage.innerText()).toContain(
       "Your payment failed, Please try again later"
     );
   }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`.toEqual()` check expects the same output. However, in some conditions Magento adds carriage return line feed to the end of the error/success message.

Change the assertion check to the `.toContain()` to match the partial fits.