### PR TITLE
[PW-7534] Enable 4 workers for CI

### DIFF
--- a/.github/workflows/magentoCI-trigger.yml
+++ b/.github/workflows/magentoCI-trigger.yml
@@ -13,4 +13,4 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ADYEN_AUTOMATION_BOT_TEST_ACCESS_TOKEN }}
     steps:
       - name: Run E2E Tests
-        run: gh workflow run e2e.yml -R Adyen/adyen-magento2 -F testBranch=${{ github.event.pull_request.head.ref}}
+        run: gh workflow run test-repo-e2e.yml -R Adyen/adyen-magento2 -F testBranch=${{ github.event.pull_request.head.ref}}

--- a/projects/magento/magentoCIContainer.config.cjs
+++ b/projects/magento/magentoCIContainer.config.cjs
@@ -26,7 +26,7 @@ const config = {
   retries: 1,
 
   /* Opt out of parallel tests on CI. */
-  workers: 2,
+  workers: 4,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { outputFolder: "/tmp/test-report", open: "never" }]],


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This change will run 4 parallel tests at a given time for magento e2e pipeline

## Tested scenarios
<!-- Description of tested scenarios -->
Tested with Magento2 scenarios


**Fixed issue**:  <!-- #-prefixed issue number -->
PW-7534
