### PR TITLE
[PW-7541] Focus only on active payment method for Magento CC

### DIFF
--- a/projects/magento/pageObjects/plugin/PaymentDetails.page.js
+++ b/projects/magento/pageObjects/plugin/PaymentDetails.page.js
@@ -46,7 +46,7 @@ export class PaymentDetailsPage {
   async selectCreditCard() {
     await this.creditCardRadioButton.click();
     await this.waitForPaymentMethodReady();
-    return new CreditCardComponentsMagento(this.page);
+    return new CreditCardComponentsMagento(this.page.locator(".payment-method._active"));
   }
 
   async selectIDeal() {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
After refactoring the checkout components to be shared amongst multiple plugins, if multiple Credit Card offerings were available on Magento payment page, the tests were failing due to strict mode violation (Having multiple items with same selectors) After this change the steps will only be executed in the active payment method even if multiple cards are available

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
