### PR TITLE
[PW-7799] Add test for payment list update after billing address change

### DIFF
--- a/projects/shopware/pageObjects/plugin/ShippingDetails.page.js
+++ b/projects/shopware/pageObjects/plugin/ShippingDetails.page.js
@@ -5,6 +5,28 @@ export class ShippingDetailsPage extends SPRBasePage {
         super(page);
         this.page = page;
 
+        //Alert message
+        this.alertMessage = page.locator(".alert-content");
+        
+        //Change Billing Address Form
+        this.changeBillingAddressButton = page.locator("text=Change billing address");
+        
+        this.currentAddressModal = page.locator(".address-editor-modal");
+        this.editAddressButton = this.currentAddressModal.locator("text=Edit address");
+
+        this.editAddressEditorWrapper = page.locator(".address-editor-create-address-wrapper").first();
+        
+        this.editSalutationDropDown = this.editAddressEditorWrapper.locator("#billing-addresspersonalSalutation");
+        this.editFirstNameField = this.editAddressEditorWrapper.locator("#billing-addresspersonalFirstName");
+        this.editLastNameField = this.editAddressEditorWrapper.locator("#billing-addresspersonalLastName");
+        this.editAddressField = this.editAddressEditorWrapper.locator("#billing-addressAddressStreet");
+        this.editPostCodeField = this.editAddressEditorWrapper.locator("#billing-addressAddressZipcode");
+        this.editCityField = this.editAddressEditorWrapper.locator("#billing-addressAddressCity");
+        this.editCountrySelectDropdown = this.editAddressEditorWrapper.locator("#billing-addressAddressCountry");
+        this.editStateSelectDropDown = this.editAddressEditorWrapper.locator("#billing-addressAddressCountryState");
+        
+        this.editSaveAddressButton = this.editAddressEditorWrapper.locator("button[type='submit']");
+        
         // Shipping details form
         this.shippingFormContainer = page.locator(".register-form");
 
@@ -51,5 +73,26 @@ export class ShippingDetailsPage extends SPRBasePage {
         await this.continueButton.click();
     }
 
+    async changeBillingAddress(user) {
+        await this.changeBillingAddressButton.click();
+        await this.currentAddressModal.waitFor({ state: "visible", timeout: 10000});
+        await this.editAddressButton.click();
+        await this.editSaveAddressButton.waitFor({ state: "visible", timeout: 10000});
+
+        await this.editAddressField.fill(user.firstName);
+        await this.editPostCodeField.fill(user.postCode);
+        await this.editCityField.fill(user.city);
+
+        const dropdownValue = await this.editCountrySelectDropdown.locator(`//option[contains(text(),'${user.countryName}')]`).getAttribute("value");
+        await this.editCountrySelectDropdown.selectOption(dropdownValue);
+
+        if (await this.editStateSelectDropDown.isVisible()) {
+            await this.editStateSelectDropDown.selectOption({ index: 2 });
+        }
+
+        await this.editSaveAddressButton.click();
+        await this.currentAddressModal.waitFor({ state: "detached", timeout: 10000});
+    }
+    
 
 }

--- a/projects/shopware/tests/EditAddressChangePaymentList.spec.js
+++ b/projects/shopware/tests/EditAddressChangePaymentList.spec.js
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import PaymentResources from "../../data/PaymentResources.js";
+import {
+    doPrePaymentChecks,
+    goToShippingWithFullCart,
+    proceedToPaymentAs
+} from "../helpers/ScenarioHelper.js";
+import { PaymentDetailsPage } from "../pageObjects/plugin/PaymentDetails.page.js";
+import { ShippingDetailsPage } from "../pageObjects/plugin/ShippingDetails.page.js";
+
+const paymentResources = new PaymentResources();
+const dutchUser = paymentResources.guestUser.dutch;
+const britishUser = paymentResources.guestUser.regular;
+
+test.describe("Payment methods", () => {
+    test.beforeEach(async ({ page }) => {
+        await goToShippingWithFullCart(page);
+        await proceedToPaymentAs(page, dutchUser);
+        await doPrePaymentChecks(page);
+    });
+
+    test.only("should be updated when the billing address is changed", async ({ page }) => {
+        const paymentDetailPage = new PaymentDetailsPage(page);
+        const shippingDetailPage = new ShippingDetailsPage(page);
+
+        await expect(await paymentDetailPage.idealSelector).toBeVisible();
+        await shippingDetailPage.changeBillingAddress(britishUser);
+
+        await expect(await shippingDetailPage.alertMessage).toContainText("address has been changed");
+        await doPrePaymentChecks(page);
+        await expect(await paymentDetailPage.idealSelector).not.toBeVisible();
+    });
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Add test for payment list update after billing address change

## Tested scenarios
<!-- Description of tested scenarios -->
- Go to shipping page with a Dutch address
- Check whether NL specific payment method is there
- Update address to UK
- Check whether NL specific methods are removed
