### PR TITLE
[PW-8407] Expand E2E coverage for 3DS2 stored cards

### DIFF
--- a/projects/magento/pageObjects/plugin/PaymentDetails.page.js
+++ b/projects/magento/pageObjects/plugin/PaymentDetails.page.js
@@ -10,7 +10,6 @@ export class PaymentDetailsPage {
   constructor(page) {
     this.page = page;
 
-    this.vaultRadioButton = page.locator("input#adyen_cc_vault_1").first();
     this.creditCardRadioButton = page.locator("#adyen_cc");
     this.idealWrapper = page.locator("#payment_form_adyen_hpp_ideal");
     this.idealRadioButton = page.locator("#adyen_ideal");
@@ -40,8 +39,11 @@ export class PaymentDetailsPage {
     await this.paymentMethodSaveCheckBox.click();
   }
 
-  async selectVault() {
-    await this.vaultRadioButton.click();
+  async selectVault(lastFourDigits) {
+    // Not ideal way of selecting saved card due to vault UI structure
+    lastFourDigits != undefined ?
+    await this.page.locator(`text=Ending ${lastFourDigits} ( expires: 3/2030 )`).click()
+    : await page.locator("input#adyen_cc_vault_1").first().click();
     await this.waitForPaymentMethodReady();
   }
 

--- a/projects/magento/tests/loggedIn/StoredCardPayment.spec.js
+++ b/projects/magento/tests/loggedIn/StoredCardPayment.spec.js
@@ -9,17 +9,48 @@ import {
   placeOrder,
 } from "../../../magento/helpers/ScenarioHelper.js";
 import { CreditCardComponentsMagento } from "../../pageObjects/checkout/CreditCardComponentsMagento.js";
+import { ThreeDS2PaymentPage } from "../../../common/redirect/ThreeDS2PaymentPage.js";
 
 const paymentResources = new PaymentResources();
 const magentoSampleUser = paymentResources.sampleRegisteredUser;
 const users = paymentResources.guestUser;
 
+/* No parallelism due to usage of same user account
+since it will cause the cart to reset */
 test.describe("Payment via stored credit card", () => {
   test.beforeEach(async ({ page }) => {
     await loginAs(page, magentoSampleUser);
     await goToShippingWithFullCart(page);
     await proceedToPaymentAs(page, undefined, false);
 
+    
+  });
+
+  test("should succeed with 3Ds2", async ({ page }) => {
+    await makeCreditCardPayment(
+      page,
+      users.regular,
+      paymentResources.masterCard3DS2,
+      paymentResources.expDate,
+      paymentResources.cvc,
+      true
+    );
+    await new ThreeDS2PaymentPage(page).validate3DS2(
+      paymentResources.threeDSCorrectPassword
+    );
+    await verifySuccessfulPayment(page);
+
+    await goToShippingWithFullCart(page);
+    await proceedToPaymentAs(page, undefined, false);
+
+    await makeVaultPayment(page, paymentResources.masterCard3DS2, paymentResources.cvc);
+    await new ThreeDS2PaymentPage(page).validate3DS2(
+      paymentResources.threeDSCorrectPassword
+    );
+    await verifySuccessfulPayment(page);
+  });
+
+  test("should succeed with no 3Ds", async ({ page }) => {
     await makeCreditCardPayment(
       page,
       users.regular,
@@ -29,13 +60,11 @@ test.describe("Payment via stored credit card", () => {
       true
     );
     await verifySuccessfulPayment(page);
-  });
 
-  test("should succeed", async ({ page }) => {
     await goToShippingWithFullCart(page);
     await proceedToPaymentAs(page, undefined, false);
 
-    await makeVaultPayment(page, paymentResources.cvc);
+    await makeVaultPayment(page, paymentResources.masterCardWithout3D, paymentResources.cvc);
     await verifySuccessfulPayment(page);
   });
 });
@@ -63,8 +92,8 @@ async function makeCreditCardPayment(
   await placeOrder(page);
 }
 
-async function makeVaultPayment(page, cvc) {
-  await new PaymentDetailsPage(page).selectVault();
+async function makeVaultPayment(page, creditCardNumber, cvc) {
+  await new PaymentDetailsPage(page).selectVault(creditCardNumber.slice(-4));
   await new CreditCardComponentsMagento(page.locator(".payment-method._active")).fillCVC(cvc);
 
   await placeOrder(page);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Expand E2E coverage for 3DS2 stored cards

## Tested scenarios
<!-- Description of tested scenarios -->
- Store a 3Ds2 and a non 3Ds card during a payment
- Pay with previously saved non 3Ds card
- Pay with previously saved 3Ds2 card
