### PR TITLE
Remove 3DS1 scenarios from Shopware 6 E2E tests

### DIFF
--- a/projects/shopware/tests/CreditCardPayment.spec.js
+++ b/projects/shopware/tests/CreditCardPayment.spec.js
@@ -35,41 +35,6 @@ test.describe.parallel("Payment via credit card", () => {
 
     });
 
-    test("with 3Ds1 should succeed", async ({ page }) => {
-
-        await makeCreditCardPayment(
-            page,
-            users.regular,
-            paymentResources.visa3DS1,
-            paymentResources.expDate,
-            paymentResources.cvc
-        );
-
-        await new ThreeDSPaymentPage(page).validate3DS(
-            paymentResources.threeDSCorrectUser,
-            paymentResources.threeDSCorrectPassword
-        );
-        await verifySuccessfulPayment(page);
-    });
-
-    test("with wrong 3Ds1 credentials should fail", async ({ page }) => {
-
-        await makeCreditCardPayment(
-            page,
-            users.regular,
-            paymentResources.visa3DS1,
-            paymentResources.expDate,
-            paymentResources.cvc
-        );
-
-        await new ThreeDSPaymentPage(page).validate3DS(
-            paymentResources.threeDSCorrectUser,
-            paymentResources.threeDSWrongPassword
-        );
-
-        await verifyFailedPayment(page);
-    });
-
     test("with 3Ds2 should succeed", async ({ page }) => {
 
         await makeCreditCardPayment(


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Remove 3DS1 scenarios from Shopware 6 E2E tests