### PR TITLE
[ECP-9179] Add wait before adding new item to cart

### DIFF
--- a/projects/magento/helpers/ScenarioHelper.js
+++ b/projects/magento/helpers/ScenarioHelper.js
@@ -14,6 +14,8 @@ export async function goToShippingWithFullCart(page, additionalItemCount = 0, it
   await productDetailsPage.addItemToCart(itemURL);
 
   if (additionalItemCount >= 1) {
+    await page.waitForLoadState("networkidle", { timeout: 20000 });
+
     await productDetailsPage.addItemWithOptionsToCart(
       "breathe-easy-tank.html",
       "M",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Multishipping tests require multiple items to be added to the cart. However, the page is redirected to the second item before the first item is added to the cart successfully.

Wait statement was added before adding new item to cart.

## Tested scenarios
<!-- Description of tested scenarios -->
- E2E workflow