### PR TITLE
[ECP-9202] Fix Shopware 6 adress selection test

### DIFF
--- a/projects/shopware/pageObjects/plugin/ShippingDetails.page.js
+++ b/projects/shopware/pageObjects/plugin/ShippingDetails.page.js
@@ -12,7 +12,7 @@ export class ShippingDetailsPage extends SPRBasePage {
         this.changeBillingAddressButton = page.locator("text=Change billing address");
         
         this.currentAddressModal = page.locator(".address-editor-modal");
-        this.editAddressButton = this.currentAddressModal.locator("text=Edit address");
+        this.editAddressButton = this.currentAddressModal.locator("text=Edit address").first();
 
         this.editAddressEditorWrapper = page.locator(".address-editor-create-address-wrapper").first();
         


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`EditAddressChangePaymentList` test was failing due to `text=Edit address` locator had been resolving into 2 elements in the page. This fix forces Playwright to use the first element found by the location in the page.

## Tested scenarios
<!-- Description of tested scenarios -->
- Shopware 6 billing address selection automated test case