### PR TITLE
[ECP-9498] Introduce test case for shopper cancellation for PayPal

### DIFF
--- a/projects/common/redirect/PayPalPaymentPage.js
+++ b/projects/common/redirect/PayPalPaymentPage.js
@@ -8,11 +8,11 @@ export class PayPalPaymentPage {
     this.passwordInput = page.locator("#password");
     this.loginButton = page.locator("#btnLogin");
     this.agreeAndPayNowButton = page.locator("#payment-submit-btn");
+    this.cancelButton = page.locator("#cancelLink");
     
     this.loggingInAnimation = page.locator("#app-loader");
     this.cookiesWrapper = page.locator("#ccpaCookieBanner");
     this.cookiesDeclineButton = this.cookiesWrapper.getByRole('button', { name: 'decline' });
-
   }
 
   async loginToPayPal(username, password) {
@@ -35,10 +35,17 @@ export class PayPalPaymentPage {
     
     await this.loggingInAnimation.waitFor({ state: "visible", timeout: 10000 });
     await this.loggingInAnimation.waitFor({ state: "hidden", timeout: 15000 });
+
     if (await this.cookiesDeclineButton.isVisible()) {
-      await this.cookiesDeclineButton.click();
-  }
+        await this.cookiesDeclineButton.click();
+    }
+
     await this.agreeAndPay();
+  }
+
+  async cancelAndGoToStore() {
+    await this.waitForPopupLoad(this.page);
+    await this.cancelButton.click();
   }
 
   async waitForPopupLoad(page) {

--- a/projects/magento/pageObjects/checkout/PayPalComponentsMagento.page.js
+++ b/projects/magento/pageObjects/checkout/PayPalComponentsMagento.page.js
@@ -1,0 +1,34 @@
+import { PayPalComponents } from "../../../common/checkoutComponents/PayPalComponents.js";
+import { PayPalPaymentPage } from "../../../common/redirect/PayPalPaymentPage.js";
+import { PaymentDetailsPage } from "../plugin/PaymentDetails.page.js";
+
+export class PayPalComponentsMagentoPage extends PayPalComponents {
+    constructor(page) {
+        super(page);
+        this.page = page;
+    }
+
+    async payViaPayPal(username, password) {
+        const popup = await this.initiatePayPalPopup()
+        await new PayPalPaymentPage(popup).makePayPalPayment(username, password);
+    }
+
+    async cancelPayPal() {
+        const popup = await this.initiatePayPalPopup();
+        await new PayPalPaymentPage(popup).cancelAndGoToStore();
+    }
+
+    async initiatePayPalPopup() {
+        const paymentDetailPage = new PaymentDetailsPage(this.page);
+        const payPalSection = await paymentDetailPage.selectPayPal();
+
+        await this.page.waitForLoadState("load", { timeout: 15000 });
+
+        const [popup] = await Promise.all([
+            this.page.waitForEvent("popup"),
+            payPalSection.proceedToPayPal(),
+        ]);
+
+        return popup;
+    }
+}

--- a/projects/magento/pageObjects/plugin/PaymentDetails.page.js
+++ b/projects/magento/pageObjects/plugin/PaymentDetails.page.js
@@ -6,12 +6,14 @@ import { IDealComponents } from "../../../common/checkoutComponents/iDealCompone
 import { OneyComponents } from "../../../common/checkoutComponents/OneyComponents.js";
 import { GiftcardComponentsMagento } from "../checkout/GiftcardComponentsMagento.js";
 import { AmazonPayComponents } from "../../../common/checkoutComponents/AmazonPayComponents.js";
+import { expect } from "@playwright/test";
 
 export class PaymentDetailsPage {
   constructor(page) {
     this.page = page;
 
     this.emailField = page.locator("#customer-email");
+    this.errorMessage = page.locator(".message-error");
 
     this.creditCardRadioButton = page.locator("#adyen_cc");
     this.idealWrapper = page.locator("#adyen-ideal-form");
@@ -151,5 +153,12 @@ export class PaymentDetailsPage {
   async waitForPaymentMethodReady() {
     await this.page.waitForLoadState("domcontentloaded", { timeout: 15000 });
     await this.activePaymentMethod.scrollIntoViewIfNeeded();
+  }
+
+  async verifyPaymentRefusal() {
+    await this.page.waitForLoadState("domcontentloaded", { timeout: 15000 });
+    expect(await this.errorMessage.innerText()).toContain(
+        "The payment is REFUSED."
+    );
   }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This test cases supports [PR #2773](https://github.com/Adyen/adyen-magento2/pull/2773) via introducing a test case for PayPal shopper cancellation.

When a shopper cancels the payment, the plugin should handle `onError` event callback of PayPal component and trigger `/payments/details` API call. As a result of this call, the order should be cancelled and an error message should be shown on the checkout page.

## Tested scenarios
<!-- Description of tested scenarios -->
- PayPal shopper cancellation