### PR TITLE
[ECP-8779]Clean-up webhooks created by E2E workflows

### DIFF
--- a/projects/magento/tests/backoffice/BackofficeAndWebhooks.spec.js
+++ b/projects/magento/tests/backoffice/BackofficeAndWebhooks.spec.js
@@ -9,7 +9,7 @@ import "../webhook/Authorisation.js";
 import "../webhook/Capture.js";
 import "../webhook/Refund.js";
 
-// // Backoffice Tests
+// Backoffice Tests
 import "./MOTO.js";
 import "./RequiredSettingsAutoConfig.js"
 import "./DeleteWebhook.js"

--- a/projects/magento/tests/backoffice/BackofficeAndWebhooks.spec.js
+++ b/projects/magento/tests/backoffice/BackofficeAndWebhooks.spec.js
@@ -9,9 +9,11 @@ import "../webhook/Authorisation.js";
 import "../webhook/Capture.js";
 import "../webhook/Refund.js";
 
-// Backoffice Tests
+// // Backoffice Tests
 import "./MOTO.js";
 import "./RequiredSettingsAutoConfig.js"
+import "./DeleteWebhook.js"
 import "./RequiredSettingsManualConfig.js"
 import "./PayByLink.js"
+
 

--- a/projects/magento/tests/backoffice/DeleteWebhook.js
+++ b/projects/magento/tests/backoffice/DeleteWebhook.js
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import PaymentResources from "../../../data/PaymentResources.js";
+
+const paymentResources = new PaymentResources();
+
+test.describe("Webhook Management", () => {
+    test("delete webhook successfully", async ({ request }) => {
+        // Send the GET request to delete the webhook
+        const response = await request.get("/adyentest/deletewebhook");
+
+        // Assert that the response is successful
+        expect(response.status()).toBe(200);
+
+        // Parse the JSON response
+        const responseBody = await response.json();
+        console.log("Response Message:", responseBody.message);
+
+        // Validate the JSON response structure and values
+        expect(responseBody.message).toContain("Webhook with ID");
+    });
+
+
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Our Management API tests create a new webhook on Adyen Customer Area every time they run. After 200 webhooks, those endpoints start to return exception messages since that is max. allowed number in adyen-main.
This PR aims to remove them with the E2E flow.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
